### PR TITLE
fix : メニューをカスタマー側だけに表示

### DIFF
--- a/front/app/src/pages/_app.tsx
+++ b/front/app/src/pages/_app.tsx
@@ -1,35 +1,32 @@
-import {CacheProvider, EmotionCache} from '@emotion/react';
+import { CacheProvider, EmotionCache } from '@emotion/react';
 import CssBaseline from '@mui/material/CssBaseline';
-import {ThemeProvider} from '@mui/material/styles';
-import type {AppProps} from 'next/app';
+import { ThemeProvider } from '@mui/material/styles';
+import type { AppProps } from 'next/app';
 import Head from 'next/head';
-import React from "react";
+import React from 'react';
 import createEmotionCache from '../createEmotionCache';
 import theme from '../theme';
-import {Menu} from "@/components/Menu";
-import Navigation from "@/components/Navigation";
-
+import Navigation from '@/components/Navigation';
 const clientSideEmotionCache = createEmotionCache();
 
 interface MyAppProps extends AppProps {
-    emotionCache?: EmotionCache;
+  emotionCache?: EmotionCache;
 }
 
 function MyApp(props: MyAppProps) {
-    const {Component, emotionCache = clientSideEmotionCache, pageProps} = props;
-    return (
-        <CacheProvider value={emotionCache}>
-            <Head>
-                <meta name='viewport' content='initial-scale=1, width=device-width'/>
-            </Head>
-            <ThemeProvider theme={theme}>
-                <CssBaseline/>
-                <Navigation/>
-                <Menu/>
-                <Component {...pageProps} />
-            </ThemeProvider>
-        </CacheProvider>
-    );
+  const { Component, emotionCache = clientSideEmotionCache, pageProps } = props;
+  return (
+    <CacheProvider value={emotionCache}>
+      <Head>
+        <meta name='viewport' content='initial-scale=1, width=device-width' />
+      </Head>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <Navigation />
+        <Component {...pageProps} />
+      </ThemeProvider>
+    </CacheProvider>
+  );
 }
 
 export default MyApp;

--- a/front/app/src/pages/customers/index.tsx
+++ b/front/app/src/pages/customers/index.tsx
@@ -1,5 +1,6 @@
 import type {NextPage} from 'next';
 import React, {useEffect, useState} from "react";
+import { Menu } from '../../components/Menu';
 import OrderView from "../../components/Orders/OrderView";
 import {Order} from "@/components/Orders";
 
@@ -19,6 +20,7 @@ const Home: NextPage = () => {
 
     return (
         <>
+            <Menu />
             <OrderView orders={orders}/>
         </>
     );

--- a/front/app/src/pages/customers/items/index.tsx
+++ b/front/app/src/pages/customers/items/index.tsx
@@ -2,7 +2,6 @@ import {Card, CardContent, Container, IconButton, Typography} from "@mui/materia
 import type {NextPage} from 'next';
 import {useEffect, useState} from "react";
 import {Menu} from "../../../components/Menu";
-import Navigation from "../../../components/Navigation";
 import Cart from "../orders/Cart";
 import {Item} from "./index";
 
@@ -19,6 +18,7 @@ const ItemsView: NextPage = () => {
 
     return (
         <>
+            <Menu/>
             <Container>
                 {items &&
                     items.map((item, index) => {

--- a/front/app/src/pages/customers/orders/[id].tsx
+++ b/front/app/src/pages/customers/orders/[id].tsx
@@ -4,6 +4,7 @@ import type { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import React, { useState, useEffect } from 'react';
 
+import { Menu } from '@/components/Menu';
 import { ItemList } from '@/components/OrderDetails/ItemList';
 import { OrderDisplay } from '@/components/OrderDetails/OrderDisplay';
 
@@ -37,6 +38,7 @@ const OrderDetailPage: NextPage = () => {
 
   return (
     <div>
+      <Menu />
       <OrderDisplay id={id} order={order} QRCodeURL={QRCodeURL} />
       <ItemList orderDetails={orderDetails} sumPrice={order?.sum_price} />
     </div>


### PR DESCRIPTION
カスタマー向けのメニューバーが全てのページに表示されていたので、カスタマー側の画面のみ表示するように修正